### PR TITLE
Fix py3 compatability issues

### DIFF
--- a/kivy3dgui/canvas3d.py
+++ b/kivy3dgui/canvas3d.py
@@ -193,7 +193,8 @@ class Canvas3D(FloatLayout):
         if self.picking:
             self.init_picking()
         self.init_motion_blur()
-        super(Canvas3D, self).__init__(**kwargs)
+        super(Canvas3D, self).__init__(
+            size_hint=kwargs.get('size_hint', (1, 1)))
         self.nt = Clock.schedule_interval(self.update_glsl, 1 / 60.)
         self._touches = {}
 

--- a/kivy3dgui/effectwidget.py
+++ b/kivy3dgui/effectwidget.py
@@ -639,8 +639,7 @@ class EffectWidget(FloatLayout):
             PopMatrix()
             self.cbs = Callback(self.reset_gl_context)
 
-
-        super(EffectWidget, self).__init__(**kwargs)
+        super(EffectWidget, self).__init__()
         self.size = C_SIZE
 
         Clock.schedule_interval(self.update_glsl, 0)

--- a/kivy3dgui/fbowidget.py
+++ b/kivy3dgui/fbowidget.py
@@ -82,7 +82,9 @@ class FboFloatLayout(FloatLayout):
         # wait that all the instructions are in the canvas to set texture
 
         self.texture = self.fbo.texture
-        super(FboFloatLayout, self).__init__(**kwargs)
+        super(FboFloatLayout, self).__init__(
+            size=kwargs.get('size', (800, 600)),
+            size_hint=kwargs.get('size_hint', (None, None)))
 
     def prepare_canvas(self, *args):
         glEnable(GL_BLEND)


### PR DESCRIPTION
So, I get the error below is a few places
```
Canvas3D: kwargs={'size_hint': (1, 1), 'picking': True, 'shadow': True, 'id': 'CANVAS3D', 'canvas_size': [800, 600]}
[INFO   ] [Shader      ] Read </home/fruitbat/Repos/zenplayer/kivy3dgui/gles2.0/shaders/dop.glsl>
 Traceback (most recent call last):
   File "/home/fruitbat/Repos/zenplayer/main.py", line 40, in <module>
     ZenPlayer().run()
   File "/usr/local/lib/python3.5/dist-packages/kivy/app.py", line 802, in run
     root = self.build()
   File "/home/fruitbat/Repos/zenplayer/main.py", line 33, in build
     self.ctrl = Controller()
   File "/home/fruitbat/Repos/zenplayer/controller.py", line 36, in __init__
     self.playing = PlayingScreen(self, name="main")
   File "/home/fruitbat/Repos/zenplayer/playing.py", line 46, in __init__
     super(PlayingScreen, self).__init__(**kwargs)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/relativelayout.py", line 265, in __init__
     super(RelativeLayout, self).__init__(**kw)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/floatlayout.py", line 65, in __init__
     super(FloatLayout, self).__init__(**kwargs)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/layout.py", line 76, in __init__
     super(Layout, self).__init__(**kwargs)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/widget.py", line 345, in __init__
     Builder.apply(self, ignored_consts=self._kwargs_applied_init)
   File "/usr/local/lib/python3.5/dist-packages/kivy/lang/builder.py", line 451, in apply
     self._apply_rule(widget, rule, rule, ignored_consts=ignored_consts)
   File "/usr/local/lib/python3.5/dist-packages/kivy/lang/builder.py", line 564, in _apply_rule
     child = cls(__no_builder=True)
   File "/home/fruitbat/Repos/zenplayer/kivy3dgui/layout3d.py", line 86, in __init__
     self.create_canvas()
   File "/home/fruitbat/Repos/zenplayer/kivy3dgui/layout3d.py", line 133, in create_canvas
     canvas_size=self.canvas_size, id="CANVAS3D")
   File "/home/fruitbat/Repos/zenplayer/kivy3dgui/canvas3d.py", line 197, in __init__
     super(Canvas3D, self).__init__(**kwargs)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/floatlayout.py", line 65, in __init__
     super(FloatLayout, self).__init__(**kwargs)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/layout.py", line 76, in __init__
     super(Layout, self).__init__(**kwargs)
   File "/usr/local/lib/python3.5/dist-packages/kivy/uix/widget.py", line 337, in __init__
     super(Widget, self).__init__(**kwargs)
   File "kivy/_event.pyx", line 254, in kivy._event.EventDispatcher.__init__ (kivy/_event.c:4922)
 TypeError: object.__init__() takes no parameters
```

Please see discussion here: https://github.com/kivy/kivy/issues/3650

The long and the short of is it that every kwarg you pass along to super has to be used, otherwise this happens. Breakpointed each and just picked out the ones I saw. Hope that catches everything you need passed on?